### PR TITLE
Feat/root landing page && Fix/.gitignore secret handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,9 @@ override.tf.json
 .vscode/
 .history/
 
-***REMOVED*** GitHub Actions secrets
-.github/workflows/*.yml
+***REMOVED*** GitHub Actions secrets (store actual secrets in GitHub repo settings, not files)
+.github/workflows/secrets.yml
+.github/workflows/.env
 
 ***REMOVED*** AWS credentials
 .aws/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,979 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>All Things Databricks — Bhavin Kukadia</title>
+    <meta name="description" content="Production-ready Databricks infrastructure templates, AI governance patterns, and security architectures across Azure, AWS, and GCP.">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+    <script src="https://code.iconify.design/3/3.1.1/iconify.min.js"></script>
+    <style>
+        *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+        :root {
+            --bg-deep:    #0d1117;
+            --bg-mid:     #161b22;
+            --bg-card:    rgba(255,255,255,0.03);
+            --bg-card-h:  rgba(255,255,255,0.06);
+            --border:     rgba(255,255,255,0.08);
+            --border-h:   rgba(255,140,0,0.45);
+            --text:       #e6edf3;
+            --muted:      #8b949e;
+            --accent:     #ff8c00;
+            --accent2:    #ffb347;
+            --azure:      #0078d4;
+            --aws:        #ff9900;
+            --gcp:        #4285f4;
+            --teal:       #14b8a6;
+            --teal-dim:   rgba(20,184,166,0.15);
+            --purple:     #a855f7;
+            --green:      #3fb950;
+        }
+
+        html { scroll-behavior: smooth; }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+            background: var(--bg-deep);
+            color: var(--text);
+            min-height: 100vh;
+            line-height: 1.6;
+            overflow-x: hidden;
+        }
+
+        /* ─── NAV ─────────────────────────────────────────── */
+        nav {
+            position: fixed;
+            top: 0; left: 0; right: 0;
+            z-index: 100;
+            background: rgba(13,17,23,0.85);
+            backdrop-filter: blur(12px);
+            border-bottom: 1px solid var(--border);
+            padding: 0 2rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            height: 56px;
+        }
+
+        .nav-logo {
+            font-size: 0.95rem;
+            font-weight: 700;
+            letter-spacing: -0.02em;
+            color: var(--text);
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.45rem;
+        }
+
+        .nav-logo .iconify { font-size: 1.3rem; color: var(--accent); }
+        .nav-logo span { color: var(--accent); }
+
+        .nav-links {
+            display: flex;
+            gap: 0.25rem;
+            list-style: none;
+        }
+
+        .nav-links a {
+            padding: 0.35rem 0.75rem;
+            border-radius: 6px;
+            color: var(--muted);
+            text-decoration: none;
+            font-size: 0.85rem;
+            transition: color 0.2s, background 0.2s;
+        }
+
+        .nav-links a:hover {
+            color: var(--text);
+            background: rgba(255,255,255,0.06);
+        }
+
+        .nav-github {
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            padding: 0.4rem 0.9rem;
+            background: rgba(255,255,255,0.06);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text);
+            text-decoration: none;
+            font-size: 0.82rem;
+            transition: background 0.2s, border-color 0.2s;
+        }
+
+        .nav-github .iconify { font-size: 1.05rem; }
+
+        .nav-github:hover {
+            background: rgba(255,255,255,0.1);
+            border-color: rgba(255,255,255,0.2);
+        }
+
+        /* ─── HERO ────────────────────────────────────────── */
+        .hero {
+            padding: 120px 2rem 80px;
+            max-width: 1100px;
+            margin: 0 auto;
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: 3rem;
+            align-items: start;
+        }
+
+        .hero-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.3rem 0.8rem;
+            background: rgba(255,140,0,0.12);
+            border: 1px solid rgba(255,140,0,0.25);
+            border-radius: 20px;
+            color: var(--accent2);
+            font-size: 0.78rem;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            margin-bottom: 1.25rem;
+        }
+
+        .hero h1 {
+            font-size: clamp(2rem, 5vw, 3.2rem);
+            font-weight: 700;
+            line-height: 1.15;
+            letter-spacing: -0.03em;
+            margin-bottom: 1rem;
+        }
+
+        .hero h1 .gradient {
+            background: linear-gradient(135deg, var(--accent) 0%, var(--accent2) 50%, #ffd700 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .hero-desc {
+            font-size: 1.05rem;
+            color: var(--muted);
+            max-width: 560px;
+            margin-bottom: 2rem;
+            line-height: 1.7;
+        }
+
+        .hero-ctas {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .btn-primary {
+            padding: 0.65rem 1.4rem;
+            background: var(--accent);
+            color: #000;
+            font-weight: 700;
+            font-size: 0.9rem;
+            border-radius: 8px;
+            text-decoration: none;
+            transition: background 0.2s, transform 0.15s;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+        }
+
+        .btn-primary .iconify { font-size: 1rem; }
+        .btn-primary:hover { background: var(--accent2); transform: translateY(-1px); }
+
+        .btn-ghost {
+            padding: 0.65rem 1.4rem;
+            background: transparent;
+            border: 1px solid var(--border);
+            color: var(--muted);
+            font-size: 0.9rem;
+            border-radius: 8px;
+            text-decoration: none;
+            transition: background 0.2s, border-color 0.2s, color 0.2s;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+        }
+
+        .btn-ghost .iconify { font-size: 1rem; }
+
+        .btn-ghost:hover {
+            background: rgba(255,255,255,0.05);
+            border-color: rgba(255,255,255,0.2);
+            color: var(--text);
+        }
+
+        /* Stats panel */
+        .hero-stats {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.75rem;
+            min-width: 240px;
+            padding-top: 0.5rem;
+        }
+
+        .stat-box {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 1rem;
+            text-align: center;
+        }
+
+        .stat-num {
+            font-size: 1.6rem;
+            font-weight: 800;
+            letter-spacing: -0.03em;
+            line-height: 1;
+            margin-bottom: 0.25rem;
+            background: linear-gradient(135deg, var(--accent), var(--accent2));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .stat-label {
+            font-size: 0.72rem;
+            color: var(--muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        /* ─── SECTIONS ────────────────────────────────────── */
+        .section {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 0 2rem 4rem;
+        }
+
+        .section-header {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+            padding-bottom: 0.75rem;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .section-header .section-icon {
+            font-size: 1.1rem;
+            display: flex;
+            align-items: center;
+            color: var(--muted);
+        }
+
+        .section-header h2 {
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--muted);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .section-header .pill {
+            padding: 0.1rem 0.5rem;
+            background: rgba(255,255,255,0.05);
+            border-radius: 20px;
+            font-size: 0.72rem;
+            color: var(--muted);
+            margin-left: auto;
+        }
+
+        /* ─── CARDS ───────────────────────────────────────── */
+        .cards {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 1rem;
+        }
+
+        .cards-3 { grid-template-columns: repeat(3, 1fr); }
+        .cards-2 { grid-template-columns: repeat(2, 1fr); }
+
+        .card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 1.4rem;
+            text-decoration: none;
+            color: inherit;
+            display: flex;
+            flex-direction: column;
+            transition: background 0.25s, border-color 0.25s, transform 0.2s, box-shadow 0.25s;
+        }
+
+        .card:hover {
+            background: var(--bg-card-h);
+            border-color: var(--border-h);
+            transform: translateY(-2px);
+            box-shadow: 0 8px 32px rgba(0,0,0,0.35);
+        }
+
+        .card-icon {
+            margin-bottom: 0.85rem;
+            display: flex;
+            align-items: center;
+        }
+
+        .card-icon .iconify {
+            font-size: 2rem;
+            color: var(--muted);
+            transition: color 0.25s;
+        }
+
+        .card:hover .card-icon .iconify { color: var(--text); }
+
+        .card h3 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-bottom: 0.4rem;
+            color: var(--text);
+        }
+
+        .card p {
+            font-size: 0.875rem;
+            color: var(--muted);
+            flex-grow: 1;
+            line-height: 1.6;
+        }
+
+        .card-footer {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-top: 1rem;
+            padding-top: 0.75rem;
+            border-top: 1px solid var(--border);
+        }
+
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            padding: 0.2rem 0.6rem;
+            border-radius: 4px;
+            font-size: 0.72rem;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+
+        .tag-azure  { background: rgba(0,120,212,0.15); color: #60b0ff; }
+        .tag-aws    { background: rgba(255,153,0,0.15);  color: var(--aws); }
+        .tag-gcp    { background: rgba(66,133,244,0.15); color: #79aeff; }
+        .tag-ai     { background: rgba(168,85,247,0.15); color: var(--purple); }
+        .tag-iac    { background: rgba(20,184,166,0.15); color: var(--teal); }
+        .tag-python { background: rgba(63,185,80,0.15);  color: var(--green); }
+        .tag-multi  { background: rgba(255,140,0,0.15);  color: var(--accent2); }
+        .tag-health { background: rgba(236,72,153,0.15); color: #f472b6; }
+
+        .card-arrow {
+            color: var(--muted);
+            display: flex;
+            align-items: center;
+            transition: color 0.2s, transform 0.2s;
+        }
+
+        .card-arrow .iconify { font-size: 1.1rem; }
+        .card:hover .card-arrow { color: var(--accent); transform: translateX(2px); }
+
+        /* ─── FEATURED CARD ───────────────────────────────── */
+        .card-featured {
+            grid-column: 1 / -1;
+            background: linear-gradient(135deg, rgba(255,140,0,0.08) 0%, rgba(255,179,71,0.05) 100%);
+            border-color: rgba(255,140,0,0.2);
+            flex-direction: row;
+            align-items: flex-start;
+            gap: 1.5rem;
+        }
+
+        .card-featured:hover { border-color: rgba(255,140,0,0.5); }
+
+        .card-featured .card-icon { flex-shrink: 0; padding-top: 0.1rem; }
+        .card-featured .card-icon .iconify { font-size: 2.6rem; color: var(--accent); }
+        .card-featured:hover .card-icon .iconify { color: var(--accent2); }
+
+        .card-featured-body { flex: 1; }
+
+        .card-featured .card-footer { border-color: rgba(255,140,0,0.15); }
+
+        /* ─── CLOUD TRIO ──────────────────────────────────── */
+        .cloud-card-azure { border-color: rgba(0,120,212,0.2); }
+        .cloud-card-azure:hover { border-color: rgba(0,120,212,0.6); box-shadow: 0 8px 32px rgba(0,120,212,0.12); }
+        .cloud-card-azure .card-icon .iconify { color: #0078d4; filter: drop-shadow(0 0 6px rgba(0,120,212,0.35)); }
+
+        .cloud-card-aws { border-color: rgba(255,153,0,0.2); }
+        .cloud-card-aws:hover { border-color: rgba(255,153,0,0.6); box-shadow: 0 8px 32px rgba(255,153,0,0.12); }
+        .cloud-card-aws .card-icon .iconify { color: #ff9900; filter: drop-shadow(0 0 6px rgba(255,153,0,0.35)); }
+
+        .cloud-card-gcp { border-color: rgba(66,133,244,0.2); }
+        .cloud-card-gcp:hover { border-color: rgba(66,133,244,0.6); box-shadow: 0 8px 32px rgba(66,133,244,0.12); }
+        .cloud-card-gcp .card-icon .iconify { color: #4285f4; filter: drop-shadow(0 0 6px rgba(66,133,244,0.35)); }
+
+        /* don't grey out cloud icons on hover */
+        .cloud-card-azure:hover .card-icon .iconify,
+        .cloud-card-aws:hover .card-icon .iconify,
+        .cloud-card-gcp:hover .card-icon .iconify { color: inherit; }
+
+        /* ─── ARTICLES ────────────────────────────────────── */
+        .article-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.6rem;
+        }
+
+        .article-item {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            padding: 0.9rem 1.1rem;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            text-decoration: none;
+            color: inherit;
+            transition: background 0.2s, border-color 0.2s, transform 0.15s;
+        }
+
+        .article-item:hover {
+            background: var(--bg-card-h);
+            border-color: rgba(255,140,0,0.3);
+            transform: translateX(3px);
+        }
+
+        .article-icon {
+            display: flex;
+            align-items: center;
+            flex-shrink: 0;
+            color: var(--accent);
+        }
+
+        .article-icon .iconify { font-size: 1rem; }
+
+        .article-title {
+            flex: 1;
+            font-size: 0.9rem;
+            color: var(--text);
+        }
+
+        .article-meta {
+            font-size: 0.78rem;
+            color: var(--muted);
+            flex-shrink: 0;
+        }
+
+        /* ─── FOOTER ──────────────────────────────────────── */
+        footer {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 3rem 2rem 4rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            border-top: 1px solid var(--border);
+        }
+
+        footer p { font-size: 0.85rem; color: var(--muted); }
+        footer a { color: var(--accent); text-decoration: none; }
+        footer a:hover { text-decoration: underline; }
+
+        .footer-links { display: flex; gap: 1.5rem; }
+
+        .footer-links a {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+            font-size: 0.85rem;
+            color: var(--muted);
+            text-decoration: none;
+            transition: color 0.2s;
+        }
+
+        .footer-links a .iconify { font-size: 1rem; }
+        .footer-links a:hover { color: var(--text); }
+
+        /* ─── RESPONSIVE ──────────────────────────────────── */
+        @media (max-width: 900px) {
+            .hero { grid-template-columns: 1fr; }
+            .hero-stats { display: flex; flex-wrap: wrap; }
+            .stat-box { flex: 1; min-width: 100px; }
+            .cards-3 { grid-template-columns: repeat(2, 1fr); }
+        }
+
+        @media (max-width: 640px) {
+            nav { padding: 0 1rem; }
+            .nav-links { display: none; }
+            .hero { padding: 90px 1.25rem 60px; gap: 2rem; }
+            .section { padding: 0 1.25rem 3rem; }
+            .cards, .cards-2, .cards-3 { grid-template-columns: 1fr; }
+            .card-featured { flex-direction: column; }
+            footer { flex-direction: column; gap: 1.5rem; text-align: center; }
+            .footer-links { flex-wrap: wrap; justify-content: center; }
+        }
+
+        /* ─── MICRO-ANIMATIONS ────────────────────────────── */
+        @keyframes fadeUp {
+            from { opacity: 0; transform: translateY(16px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+
+        .hero > * { animation: fadeUp 0.5s ease both; }
+        .hero > *:nth-child(2) { animation-delay: 0.1s; }
+    </style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+    <a href="#" class="nav-logo">
+        <span class="iconify" data-icon="simple-icons:databricks"></span>
+        <span>databricks</span>.portfolio
+    </a>
+    <ul class="nav-links">
+        <li><a href="#clouds">Clouds</a></li>
+        <li><a href="#ai">AI Governance</a></li>
+        <li><a href="#guides">Guides</a></li>
+        <li><a href="#connectors">Connectors</a></li>
+        <li><a href="#articles">Articles</a></li>
+    </ul>
+    <a href="https://github.com/bhavink/databricks" target="_blank" class="nav-github">
+        <span class="iconify" data-icon="tabler:brand-github"></span>
+        bhavink/databricks
+    </a>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+    <div>
+        <div class="hero-badge">⚡ Production-Ready · Open Source</div>
+        <h1>All Things<br><span class="gradient">Databricks</span></h1>
+        <p class="hero-desc">
+            Production-ready infrastructure templates, AI governance patterns, and security architectures
+            for Databricks on Azure, AWS, and GCP — built by
+            <a href="https://www.linkedin.com/in/bhavink/" target="_blank" style="color:var(--accent); text-decoration:none;">Bhavin Kukadia</a>.
+        </p>
+        <div class="hero-ctas">
+            <a href="https://github.com/bhavink/databricks/blob/master/adb4u/docs/01-QUICKSTART.md" target="_blank" class="btn-primary">
+                <span class="iconify" data-icon="tabler:rocket"></span>
+                Quick Start
+            </a>
+            <a href="ai-governance/index.html" class="btn-ghost">
+                <span class="iconify" data-icon="tabler:robot"></span>
+                AI Governance Guide
+            </a>
+            <a href="https://github.com/bhavink/databricks/tree/master/guides" target="_blank" class="btn-ghost">
+                <span class="iconify" data-icon="tabler:book"></span>
+                Cross-Cloud Guides
+            </a>
+        </div>
+    </div>
+    <div class="hero-stats">
+        <div class="stat-box">
+            <div class="stat-num">200+</div>
+            <div class="stat-label">Terraform Files</div>
+        </div>
+        <div class="stat-box">
+            <div class="stat-num">127+</div>
+            <div class="stat-label">Docs Pages</div>
+        </div>
+        <div class="stat-box">
+            <div class="stat-num">3</div>
+            <div class="stat-label">Cloud Providers</div>
+        </div>
+        <div class="stat-box">
+            <div class="stat-num">13+</div>
+            <div class="stat-label">Blog Articles</div>
+        </div>
+    </div>
+</section>
+
+<!-- CLOUD DEPLOYMENTS -->
+<section class="section" id="clouds">
+    <div class="section-header">
+        <span class="section-icon"><span class="iconify" data-icon="tabler:cloud-computing"></span></span>
+        <h2>Cloud Deployments</h2>
+        <span class="pill">Infrastructure as Code</span>
+    </div>
+    <div class="cards cards-3">
+
+        <a href="https://github.com/bhavink/databricks/tree/master/adb4u" target="_blank" class="card cloud-card-azure">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:brand-azure"></span>
+            </div>
+            <h3>Azure Databricks</h3>
+            <p>
+                Modular Terraform templates for Non-PL, Full Private (air-gapped),
+                and Hub-Spoke patterns. 8 reusable modules covering networking,
+                workspace, Unity Catalog, Key Vault, private endpoints, and monitoring.
+            </p>
+            <div class="card-footer">
+                <div style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+                    <span class="tag tag-azure">Azure</span>
+                    <span class="tag tag-iac">Terraform</span>
+                </div>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/tree/master/awsdb4u" target="_blank" class="card cloud-card-aws">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:brand-aws"></span>
+            </div>
+            <h3>AWS Databricks</h3>
+            <p>
+                Private Link workspace templates with full Data Exfiltration Protection
+                (DEP) controls. Covers VPC design, PrivateLink endpoints, IAM roles,
+                cross-account setups, and S3 data access patterns.
+            </p>
+            <div class="card-footer">
+                <div style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+                    <span class="tag tag-aws">AWS</span>
+                    <span class="tag tag-iac">Terraform</span>
+                </div>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/tree/master/gcpdb4u" target="_blank" class="card cloud-card-gcp">
+            <div class="card-icon">
+                <span class="iconify" data-icon="simple-icons:googlecloud"></span>
+            </div>
+            <h3>GCP Databricks</h3>
+            <p>
+                VPC Service Controls (VPC-SC), Private Service Connect (PSC), and
+                CMEK implementations. Includes Workload Identity Federation, GCS
+                connectors, and data exfiltration prevention patterns.
+            </p>
+            <div class="card-footer">
+                <div style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+                    <span class="tag tag-gcp">GCP</span>
+                    <span class="tag tag-iac">Terraform</span>
+                </div>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+    </div>
+</section>
+
+<!-- AI GOVERNANCE -->
+<section class="section" id="ai">
+    <div class="section-header">
+        <span class="section-icon"><span class="iconify" data-icon="tabler:robot"></span></span>
+        <h2>AI Governance</h2>
+        <span class="pill">Auth &amp; Authorization</span>
+    </div>
+    <div class="cards">
+
+        <a href="ai-governance/index.html" class="card card-featured">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:shield-lock"></span>
+            </div>
+            <div class="card-featured-body">
+                <h3>Interactive AI Governance Guide</h3>
+                <p>
+                    Scroll-based animated visualizations covering all Databricks AI product authentication
+                    and authorization patterns — Agent Bricks, Genie Space, Databricks Apps, MCP, AI Gateway.
+                    Interactive decision trees help you choose the right pattern for your workload.
+                </p>
+                <div class="card-footer">
+                    <div style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+                        <span class="tag tag-ai">AI Gateway</span>
+                        <span class="tag tag-ai">MCP</span>
+                        <span class="tag tag-ai">Agent Bricks</span>
+                        <span class="tag tag-iac">Unity Catalog</span>
+                    </div>
+                    <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+                </div>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/blob/master/ai-governance/ORCHESTRATION-ARCHITECTURE.md" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:cloud-network"></span>
+            </div>
+            <h3>Orchestration Architecture</h3>
+            <p>End-to-end governed orchestration hub covering all Databricks AI services in one authoritative reference.</p>
+            <div class="card-footer">
+                <span class="tag tag-ai">Architecture</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/blob/master/ai-governance/01-AUTHENTICATION-PATTERNS.md" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:lock"></span>
+            </div>
+            <h3>Authentication Patterns</h3>
+            <p>Service Principal passthrough, On-Behalf-Of-User (OBO), and OAuth Token Federation — with full code examples.</p>
+            <div class="card-footer">
+                <span class="tag tag-ai">Auth</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/blob/master/ai-governance/02-AUTHORIZATION-WITH-UC.md" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:database"></span>
+            </div>
+            <h3>Authorization with Unity Catalog</h3>
+            <p>Four-layer access control: workspace restrictions, UC privileges, ABAC governed tags, and row/column-level security.</p>
+            <div class="card-footer">
+                <span class="tag tag-iac">Unity Catalog</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/blob/master/ai-governance/03-GENIE-SPACE-DEEP-DIVE.md" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:sparkles"></span>
+            </div>
+            <h3>Genie Space Deep Dive</h3>
+            <p>Multi-team access patterns for 1000+ users, scaling Genie with complex Unity Catalog governance models.</p>
+            <div class="card-footer">
+                <span class="tag tag-ai">Genie</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/tree/master/ai-governance/audit-logging" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:chart-bar"></span>
+            </div>
+            <h3>Audit Logging &amp; Monitoring</h3>
+            <p>System tables monitoring and audit queries for tracking AI product usage, access patterns, and governance compliance.</p>
+            <div class="card-footer">
+                <span class="tag tag-ai">Observability</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+    </div>
+</section>
+
+<!-- GUIDES -->
+<section class="section" id="guides">
+    <div class="section-header">
+        <span class="section-icon"><span class="iconify" data-icon="tabler:book"></span></span>
+        <h2>Cross-Cloud Guides</h2>
+        <span class="pill">Start Here</span>
+    </div>
+    <div class="cards cards-2">
+
+        <a href="https://github.com/bhavink/databricks/blob/master/guides/authentication.md" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:key"></span>
+            </div>
+            <h3>Authentication Guide</h3>
+            <p>Set up Terraform authentication for Azure, AWS, or GCP. Zero jargon — step-by-step from scratch.</p>
+            <div class="card-footer">
+                <span class="tag tag-multi">All Clouds</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/blob/master/guides/networking.md" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:network"></span>
+            </div>
+            <h3>Networking Guide</h3>
+            <p>Complete multi-cloud networking reference covering VNet, VPC, VPC-SC, Private Link, and troubleshooting flows.</p>
+            <div class="card-footer">
+                <span class="tag tag-multi">All Clouds</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/blob/master/guides/identities.md" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:id-badge"></span>
+            </div>
+            <h3>Identities Guide</h3>
+            <p>How Databricks accesses your cloud account — managed identities, service accounts, IAM roles explained clearly.</p>
+            <div class="card-footer">
+                <span class="tag tag-multi">All Clouds</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/blob/master/guides/common-questions.md" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:question-mark"></span>
+            </div>
+            <h3>Common Questions &amp; Answers</h3>
+            <p>Quick answers to the most frequently asked questions about Databricks infrastructure and security setup.</p>
+            <div class="card-footer">
+                <span class="tag tag-multi">Reference</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+    </div>
+</section>
+
+<!-- HEALTHCARE CONNECTORS -->
+<section class="section" id="connectors">
+    <div class="section-header">
+        <span class="section-icon"><span class="iconify" data-icon="tabler:activity-heartbeat"></span></span>
+        <h2>Healthcare Connectors</h2>
+        <span class="pill">Spark Declarative Pipelines</span>
+    </div>
+    <div class="cards">
+
+        <a href="https://github.com/bhavink/databricks/blob/master/connectors/DESIGN.md" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:ruler"></span>
+            </div>
+            <h3>Architecture &amp; Design</h3>
+            <p>967-line architecture document covering streaming patterns, resilience strategies, data quality, and medallion lakehouse design for healthcare ingestion.</p>
+            <div class="card-footer">
+                <span class="tag tag-health">Architecture</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/tree/master/connectors/pipelines/healthcare_ingestion/hl7v2" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:layers-union"></span>
+            </div>
+            <h3>HL7v2 Pipeline</h3>
+            <p>Full bronze to silver to gold pipeline for HL7v2 messages. 11 curated tables covering ADT, ORM, ORU, and more message types.</p>
+            <div class="card-footer">
+                <div style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+                    <span class="tag tag-health">HL7v2</span>
+                    <span class="tag tag-python">Python</span>
+                </div>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/tree/master/connectors/pipelines/healthcare_ingestion/fhir" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:activity-heartbeat"></span>
+            </div>
+            <h3>FHIR R4 Pipeline</h3>
+            <p>REST API ingestion and streaming pipeline for FHIR R4. 8 curated tables, 1579-line parser with validation, quarantine patterns, and schema evolution support.</p>
+            <div class="card-footer">
+                <div style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+                    <span class="tag tag-health">FHIR R4</span>
+                    <span class="tag tag-python">Python</span>
+                </div>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+    </div>
+</section>
+
+<!-- UTILITIES -->
+<section class="section">
+    <div class="section-header">
+        <span class="section-icon"><span class="iconify" data-icon="tabler:tools"></span></span>
+        <h2>Utilities</h2>
+        <span class="pill">Helper Scripts</span>
+    </div>
+    <div class="cards cards-2">
+
+        <a href="https://github.com/bhavink/databricks/tree/master/databricks-utils/extract-databricks-ips" target="_blank" class="card">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:world"></span>
+            </div>
+            <h3>Extract Databricks IPs</h3>
+            <p>
+                Official API-backed tool to extract Databricks IP ranges by region and service type.
+                Supports JSON, CSV, and plain CIDR output formats. Includes runbook and tests.
+            </p>
+            <div class="card-footer">
+                <div style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+                    <span class="tag tag-python">Python</span>
+                    <span class="tag tag-multi">All Clouds</span>
+                </div>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+        <a href="https://github.com/bhavink/databricks/tree/master/archive" target="_blank" class="card" style="opacity:0.7;">
+            <div class="card-icon">
+                <span class="iconify" data-icon="tabler:archive"></span>
+            </div>
+            <h3>Archive</h3>
+            <p>Legacy content including Databricks jump-start notebooks, Spark/MLflow/Delta Lake examples, and REST API Postman collections.</p>
+            <div class="card-footer">
+                <span class="tag" style="background:rgba(255,255,255,0.06);color:var(--muted);">Legacy</span>
+                <span class="card-arrow"><span class="iconify" data-icon="tabler:arrow-right"></span></span>
+            </div>
+        </a>
+
+    </div>
+</section>
+
+<!-- ARTICLES -->
+<section class="section" id="articles">
+    <div class="section-header">
+        <span class="section-icon"><span class="iconify" data-icon="tabler:news"></span></span>
+        <h2>Published Articles</h2>
+        <span class="pill">Databricks Blog</span>
+    </div>
+    <div class="article-list">
+
+        <a href="https://www.databricks.com/blog/unified-approach-data-exfiltration-protection-databricks" target="_blank" class="article-item">
+            <span class="article-icon"><span class="iconify" data-icon="tabler:shield-lock"></span></span>
+            <span class="article-title">A Unified Approach to Data Exfiltration Protection on Databricks</span>
+            <span class="article-meta">Aug 2025</span>
+        </a>
+
+        <a href="https://www.databricks.com/blog/bigquery-adds-first-party-support-delta-lake" target="_blank" class="article-item">
+            <span class="article-icon"><span class="iconify" data-icon="tabler:database-share"></span></span>
+            <span class="article-title">BigQuery Adds First-Party Support for Delta Lake</span>
+            <span class="article-meta">Jun 2024</span>
+        </a>
+
+        <a href="https://www.databricks.com/blog/how-delta-sharing-enables-secure-end-end-collaboration" target="_blank" class="article-item">
+            <span class="article-icon"><span class="iconify" data-icon="tabler:share"></span></span>
+            <span class="article-title">How Delta Sharing Enables Secure End-to-End Collaboration</span>
+            <span class="article-meta">May 2024</span>
+        </a>
+
+        <a href="https://www.databricks.com/blog/data-exfiltration-protection-azure-databricks" target="_blank" class="article-item">
+            <span class="article-icon"><span class="iconify" data-icon="tabler:brand-azure"></span></span>
+            <span class="article-title">Data Exfiltration Protection with Azure Databricks</span>
+            <span class="article-meta">Mar 2024</span>
+        </a>
+
+        <a href="https://www.databricks.com/blog/author/bhavin-kukadia" target="_blank" class="article-item" style="border-color:rgba(255,140,0,0.2);">
+            <span class="article-icon" style="color:var(--accent2);"><span class="iconify" data-icon="tabler:external-link"></span></span>
+            <span class="article-title" style="color:var(--accent2);">View all 13+ articles on Databricks Blog</span>
+            <span class="article-meta"></span>
+        </a>
+
+    </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+    <p>
+        Built by <a href="https://www.linkedin.com/in/bhavink/" target="_blank">Bhavin Kukadia</a> ·
+        <a href="https://github.com/bhavink/databricks" target="_blank">github.com/bhavink/databricks</a>
+    </p>
+    <div class="footer-links">
+        <a href="https://www.databricks.com/blog/author/bhavin-kukadia" target="_blank">
+            <span class="iconify" data-icon="tabler:news"></span> Blog
+        </a>
+        <a href="https://www.linkedin.com/in/bhavink/" target="_blank">
+            <span class="iconify" data-icon="tabler:brand-linkedin"></span> LinkedIn
+        </a>
+        <a href="https://github.com/bhavink/databricks" target="_blank">
+            <span class="iconify" data-icon="tabler:brand-github"></span> GitHub
+        </a>
+        <a href="ai-governance/index.html">
+            <span class="iconify" data-icon="tabler:shield-lock"></span> AI Governance
+        </a>
+        <a href="https://github.com/bhavink/databricks" target="_blank">
+            <span class="iconify" data-icon="tabler:brand-github"></span> Repo
+        </a>
+    </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
Added a root index.html, an interactive landing page that serves as a visual for everything in the repo. It pulls    
together all the sections (Azure, AWS, GCP, AI Governance, Healthcare Connectors, Guides, Utilities, published articles) into a single page with your stats, and links that go directly to the right GitHub pages rather    
than breaking on Pages. 

Also quietly fixed a possible bug in .gitignore - line 49 was blocking .github/workflows/*.yml, which would have silently eaten any CI/CD workflows you tried to add. Swapped it for a scoped pattern that only ignores actual secrets files.

No existing files were touched. Happy to adjust styling, colours, or content to better match your vision - just leave a comment and I'll update.

Thank you for using your personal time to present and answer questions during the IU Cyber club meeting yesterday, And Thanks for putting this repo together. It's genuinely one of the best Databricks references out there.